### PR TITLE
Switch to lists for JEI hammer catalysts for better visual ordering

### DIFF
--- a/src/main/java/dev/ftb/mods/sluice/integration/jei/JEIPlugin.java
+++ b/src/main/java/dev/ftb/mods/sluice/integration/jei/JEIPlugin.java
@@ -18,25 +18,26 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.fml.RegistryObject;
 
-import java.util.HashSet;
+import java.util.Arrays;
+import java.util.List;
 
 @JeiPlugin
 public class JEIPlugin implements IModPlugin {
     public static final ResourceLocation SLUICE_JEI = new ResourceLocation(FTBSluice.MOD_ID, "jei");
-    public static HashSet<RegistryObject<Item>> HAMMERS = new HashSet<RegistryObject<Item>>() {{
-        this.add(SluiceModItems.WOODEN_HAMMER);
-        this.add(SluiceModItems.STONE_HAMMER);
-        this.add(SluiceModItems.IRON_HAMMER);
-        this.add(SluiceModItems.GOLD_HAMMER);
-        this.add(SluiceModItems.DIAMOND_HAMMER);
-        this.add(SluiceModItems.NETHERITE_HAMMER);
-    }};
-    public static HashSet<RegistryObject<BlockItem>> AUTO_HAMMERS = new HashSet<RegistryObject<BlockItem>>() {{
-        this.add(SluiceModItems.IRON_AUTO_HAMMER);
-        this.add(SluiceModItems.GOLD_AUTO_HAMMER);
-        this.add(SluiceModItems.DIAMOND_AUTO_HAMMER);
-        this.add(SluiceModItems.NETHERITE_AUTO_HAMMER);
-    }};
+    public static List<RegistryObject<Item>> HAMMERS = Arrays.asList(
+        SluiceModItems.WOODEN_HAMMER,
+        SluiceModItems.STONE_HAMMER,
+        SluiceModItems.IRON_HAMMER,
+        SluiceModItems.GOLD_HAMMER,
+        SluiceModItems.DIAMOND_HAMMER,
+        SluiceModItems.NETHERITE_HAMMER
+    );
+    public static List<RegistryObject<BlockItem>> AUTO_HAMMERS = Arrays.asList(
+        SluiceModItems.IRON_AUTO_HAMMER,
+        SluiceModItems.GOLD_AUTO_HAMMER,
+        SluiceModItems.DIAMOND_AUTO_HAMMER,
+        SluiceModItems.NETHERITE_AUTO_HAMMER
+    );
 
     @Override
     public ResourceLocation getPluginUid() {


### PR DESCRIPTION
This PR probably should have been part of https://github.com/FTBTeam/FTB-Sluice/pull/9 but it didn't come to mind until this morning.

The hammer catalysts used a hashset originally, which leads to indeterminate ordering in the JEI display. I maintained this with the auto hammer set as well to mirror the original source in #9. This PR changes both of those to lists, ordering the hammers by tier (wood -> stone -> iron, etc) as well as the auto hammers below them, in the catalyst display.

<img src="https://user-images.githubusercontent.com/21695337/161443441-9003cde4-0550-4019-87ce-9d36d2961a9d.png" alt="old vs new catalysts display" width="180">